### PR TITLE
Context for JSON response assertions now fully outputs JSON object

### DIFF
--- a/lib/api-easy.js
+++ b/lib/api-easy.js
@@ -236,7 +236,7 @@ exports.describe = function (text) {
       
       // Setup the JSON response assertion if we have the appropriate arguments.
       if (result) {
-        context['should respond with ' + Object.keys(result).join(', ')] = function (err, res, body) {
+        context['should respond with ' + JSON.stringify(result)] = function (err, res, body) {
           try {
             assert.isNull(err);
             var testResult = JSON.parse(body);


### PR DESCRIPTION
Context for JSON response assertions now fully outputs JSON object using JSON.stringify. This aids in readability, and helps to make the tests act as pseudo-documentation for an api.
