### PR TITLE
Support urlencoded POST data

### DIFF
--- a/lib/api-easy.js
+++ b/lib/api-easy.js
@@ -346,7 +346,11 @@ exports.describe = function (text) {
       // [request module](http://github.com/mikeal/request)
       //
       if (data) {
-        outgoing.body = JSON.stringify(data);
+        if (this.outgoing.headers['Content-Type'] == 'application/x-www-form-urlencoded') {
+            outgoing.body = qs.stringify(data);
+        } else {
+            outgoing.body = JSON.stringify(data);
+        }
       }
       
       // Set the `uri` and `method` properties of the request options `outgoing`


### PR DESCRIPTION
Instead of assuming all POST data is JSON, take a look to see if the Content-Type header has been set to "application/x-www-form-urlencoded" and if so format the data as such.
