### PR TITLE
pass json exceptions through to vows

### DIFF
--- a/lib/api-easy.js
+++ b/lib/api-easy.js
@@ -237,20 +237,9 @@ exports.describe = function (text) {
       // Setup the JSON response assertion if we have the appropriate arguments.
       if (result) {
         context['should respond with ' + JSON.stringify(result).substring(0, 50)] = function (err, res, body) {
-          try {
-            assert.isNull(err);
-            var testResult = JSON.parse(body);
-            assert.deepEqual(result, testResult);
-          }
-          catch (ex) {
-            //
-            // In the case of a JSON parse exception we need to alert the vows
-            // suite. Not quite sure the best approach here. **cloudhead?**
-            //
-            // **TODO _(indexzero)_**: Something better here
-            //
-            assert.equal('Error parsing JSON returned', 'There was an');
-          }
+          assert.isNull(err);
+          var testResult = JSON.parse(body);
+          assert.deepEqual(result, testResult);
         };
       }
       


### PR DESCRIPTION
I was having trouble asserting json responses, when the response was valid json, but didn't match the expected json, I was getting "There was an error parsing json returned".

It seems that this try-catch block was trapping errors raised by the `assert.deepEqual` call. It seems that removing this block passes the errors through to vows as expected. It also seems to pass the json errors through to vows as well.
