### PR TITLE
Add exportTo() alias to avoid reserved word issues

### DIFF
--- a/lib/api-easy.js
+++ b/lib/api-easy.js
@@ -316,6 +316,9 @@ exports.describe = function (text) {
     // needing to call `apiEasySuite.suite.export(module)`. You should only 
     // call this method once in a given test file.  
     //
+    // The method exportTo(module) is provided as an alias to export(module)
+    // if you want to avoid using the reserved JavaScript `export` word
+    //
     // You can also call `.run()` which will run the specified suite just 
     // as if you were using vows directly.
     //
@@ -326,6 +329,9 @@ exports.describe = function (text) {
       
       this.suite.export(target);
       return this;
+    },
+    exportTo: function (target) {
+      return this.export(target);
     },
     run: function (options, callback) {
       if (this.batch) {

--- a/test/core-test.js
+++ b/test/core-test.js
@@ -22,7 +22,7 @@ vows.describe('api-easy/core').addBatch({
     "and a valid suite": {
       "it should have the correct methods set": function (suite) {
         ['discuss', 'use', 'setHeaders', 'path', 'unpath', 'root', 'get', 'put', 
-          'post', 'del', 'expect', 'next', 'export', '_request', '_currentTest'].forEach(function (key) {
+          'post', 'del', 'expect', 'next', 'export', 'exportTo', '_request', '_currentTest'].forEach(function (key) {
           assert.isFunction(suite[key]);
         });
       },

--- a/test/vows-test.js
+++ b/test/vows-test.js
@@ -44,7 +44,7 @@ vows.describe('api-easy/vows').addBatch({
               var easy = suite[method]();
               assert.isObject(easy);
               ['discuss', 'use', 'setHeaders', 'path', 'unpath', 'root', 'get', 'put', 
-               'post', 'del', 'expect', 'next', 'export', '_request', '_currentTest', 'addBatch'].forEach(function (key) {
+               'post', 'del', 'expect', 'next', 'export', 'exportTo', '_request', '_currentTest', 'addBatch'].forEach(function (key) {
                 assert.isFunction(easy[key]);
               });
             });


### PR DESCRIPTION
`export` is a reserved word in JavaScript, so it is illegal to use it as
an identifier. Many linting tools will complain about a regular call to
export(module), requiring the following (ugly) fix:
-    ).export(module);
-    )['export'](module);

To encourage good style while maintaining backwards compatibility,
the exportTo(module) alias can be used as a syntactically valid
replacement for export(module).

Closely related issue/fix in vows:

https://github.com/cloudhead/vows/issues/27
https://github.com/cloudhead/vows/commit/398443dab28d4ed3aa313bdf22915df097a9a451
