### PR TITLE
Disable request.jar

### DIFF
--- a/lib/api-easy.js
+++ b/lib/api-easy.js
@@ -9,7 +9,7 @@ var assert = require('assert'),
     fs = require('fs'),
     path = require('path'),
     qs = require('querystring'),
-    request = require('request'),
+    request = require('request').defaults({jar: false}),
     vows = require('vows');
 
 //

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -103,6 +103,10 @@ helpers.startServer = function (port) {
   router.get('/restricted', function () {
     this.res.json(200, {}, { authorized: true });
   });
+  
+  router.get('/cookie', function() {
+    this.res.json(200, {}, {cookie: this.req.headers['cookie']});
+  });
     
   http.createServer(function (req, res) {
     req.body = '';

--- a/test/run-test.js
+++ b/test/run-test.js
@@ -55,14 +55,21 @@ vows.describe('api-easy/run').addBatch({
              .next()
              .get('/restricted')
                .expect(200, { authorized: true })
+             .setHeader('cookie', 'a cookie value')
+             .get('/cookie')
+               .expect(200)
+               .expect('should respond with the cookie-header', function(err, res, body) {
+                 var result = JSON.parse(body);
+                 assert.equal(result.cookie, 'a cookie value');
+               })
              .run(this.callback.bind(null, null));
       },
       "should run and respond with no errors": function (ign, results) {
         assert.equal(results.errored, 0);
         assert.equal(results.broken, 0);
         assert.equal(results.pending, 0);
-        assert.equal(results.honored, 11);
-        assert.equal(results.total, 11);
+        assert.equal(results.honored, 13);
+        assert.equal(results.total, 13);
       }
     }
   }


### PR DESCRIPTION
Request has since 2.9.0 introduced support for cookie jars.

It means that if a Cookie-header is sent without using the cookie jar it will be overwritten by request.

Disabling the cookie jar functionality in request makes api-easy work like it used to. Tests passes when using an older version of request (2.2.9) also.
