### PR TITLE
removes non-standard content type "application/patch+json"

### DIFF
--- a/lib/api-easy.js
+++ b/lib/api-easy.js
@@ -187,10 +187,7 @@ exports.describe = function (text) {
     },
     patch: function (/* [uri, data, params] */) {
       var args = Array.prototype.slice.call(arguments);
-      var prev_head = this.getHeader('Content-Type');
-      this.setHeader('Content-Type', 'application/patch+json');
       var req = this._request.apply(this, ['patch'].concat(args));
-      this.setHeader('Content-Type', prev_head);
       return req;
     },
     del: function (/* [uri, data, params] */) {


### PR DESCRIPTION
up to client code to set their own headers
application/patch+json content type prevents body data from being json stringified
