### PR TITLE
Upload files AND fields

### DIFF
--- a/lib/api-easy.js
+++ b/lib/api-easy.js
@@ -202,26 +202,37 @@ exports.describe = function (text) {
       args.splice(1, -1, null);
       return this._request.apply(this, ['head'].concat(args));
     },
-    uploadFile: function (/* [uri, filepath, filePartName] */) {
+    uploadFile: function (/* [uri, filepath, filePartName, data] */) {
       var args = Array.prototype.slice.call(arguments),
           filepath = args.splice(1, 1),
           filePartName = args.splice(1, 1),
+          data = args.splice(1, 1),
           filename = path.basename(filepath);
-          
       args.push(function (outgoing, callback) {
         //
         // TODO replace request/multipart with better implementation with
         // low memory consumption
         //
         fs.readFile(filepath[0], function (err, fileData) {
-          outgoing.multipart = [{
+          var multipart = outgoing.multipart = [];
+          if(data){
+            Object.keys(data[0]).forEach(function(key){
+              var value = data[0][key];
+              multipart.push({
+                'Content-Disposition': 'form-data; name="' + key + '"',
+                body: value
+              });
+            });
+          }
+
+          multipart.push({
               'content-type': 'application/octet-stream',
               'Content-Transfer-Encoding': 'binary',
               'Content-Disposition': 'form-data; name="' + filePartName + '"; filename="' + filename + '"',
               'body': fileData
-          }];
+          });
           
-          request(outgoing, callback);  
+          request(outgoing, callback);
         });
       });
       

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -135,7 +135,7 @@ helpers.startFileEchoServer = function (port) {
       })
       .on('end', function () {
         response.writeHead(200, {'content-type': request.headers['content-type']});
-        response.end(fs.readFileSync(files[0][1].path));
+        response.end(JSON.stringify({fields : fields, file: fs.readFileSync(files[0][1].path).toString() }));
       });
     form.parse(request);
   }).listen(8080);

--- a/test/upload-test.js
+++ b/test/upload-test.js
@@ -41,10 +41,12 @@ vows.describe('api-easy/upload').addBatch({
         suite.use('localhost', 8080)
              .followRedirect(false)
              .setHeader("content-type", 'multipart/form-data')
-             .uploadFile('/upload', __dirname + "/file.txt", 'file')
-               .expect(200)
+             .uploadFile('/upload', __dirname + "/file.txt", 'file', {
+               description: 'A description to send'
+             }).expect(200)
                .expect("should return file", function (err, res, body) {
-                  assert.equal('TEST FILE CONTENT HERE', body);
+                  assert.include(body, 'TEST FILE CONTENT HERE');
+                  assert.include(body, 'A description to send');
                })
              .run(this.callback.bind(null, null));
       },


### PR DESCRIPTION
Hi, 

Uploading files with api-easy is great, but it's even better when we can send fields too.

```
.uploadFile('/upload', __dirname + "/file.txt", 'file', {
    description: 'A description to send'
})
```
