### PR TITLE
Build _request urls at topic execution time.

### DIFF
--- a/lib/api-easy.js
+++ b/lib/api-easy.js
@@ -464,6 +464,12 @@ exports.describe = function (text) {
       //
       outgoing.method = method;
       
+      // Set outgoing here first for tests that rely on it.
+      var port = self.port && self.port !== 80 ? ':' + self.port : '';
+      outgoing.uri = self.secure ? 'https://' : 'http://';
+      outgoing.uri += self.auth ? self.auth + '@' : '';
+      outgoing.uri += self.host + port + fullUri;
+
       //
       // Create the description for this test. This is currently static.
       // **Remark _(indexzero)_**: Do users care if these strings are configurable?


### PR DESCRIPTION
This change allows changes to .host and .port to actually be useful
when changed after calls to .get and whatnot are made.

Is this a change you're interested in?

This allows the following code to work.

``` javascript
var suite = require('api-easy').describe('tests'),
    assert = require('assert')

suite.addBatch({
    'context': {
        topic: function() {
            this.callback(true)
        },
        'test': function(success) {
            suite.use('example.com')
            assert(success);
        }
    }
});

suite.addBatch({
    'using example': function() {
        assert.equal(suite.host, 'example.com');
    }
});

suite
    // I want to continue to .use('example.com')
    .get('test')
        .expect(200)

    .export(module);
```
