### PR TITLE
Upgrade Vows to 0.7.x and PkgInfo to 0.3.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,9 +17,9 @@
     "vows"
   ],
   "dependencies": {
-    "pkginfo": "0.2.x",
+    "pkginfo": "0.3.x",
     "request": "2.x.x",
-    "vows": "0.6.x",
+    "vows": "0.7.x",
     "qs": "0.5.x"
   },
   "devDependencies": {


### PR DESCRIPTION
Please accept my pull request to allow api-easy works fine with vows 0.7 and node 0.10
