### PR TITLE
Allow unsafe SSL through an option

### DIFF
--- a/lib/api-easy.js
+++ b/lib/api-easy.js
@@ -53,7 +53,7 @@ exports.describe = function (text) {
     paths: [],
     batch: {},
     batches: [],
-    
+
     //
     // ### Add and Remove BDD Discussion
     // Simple pathing for adding contextual description to sets of tests. 
@@ -80,7 +80,7 @@ exports.describe = function (text) {
       this.discussion.splice(-1 * length, length);
       return this;
     },
-    
+
     //
     // ### Setup Remote API Location / Options
     // Configure the remote `host`, `port`, and miscellaneous
@@ -95,6 +95,7 @@ exports.describe = function (text) {
       this.port   = port || 80;
       this.secure = options.secure || false;
       this.auth   = options.auth;
+      this.strictSSL = options.strictSSL || false;
 
       //
       // **TODO _(indexzero)_:** Setup `this.options` here (i.e. options for the SUITE, not the REQUEST)
@@ -134,7 +135,7 @@ exports.describe = function (text) {
       delete this.outgoing.headers[key];
       return this;
     },
-    
+
     //
     // ### Manipulate Base Path 
     // Control the base path used for a given test in this suite. Append a path
@@ -154,7 +155,7 @@ exports.describe = function (text) {
       this.paths = [path];
       return this;
     },
-    
+
     //
     // ### Dynamically set Outgoing Request Options
     // Often it is necessary to set some HTTP options conditionally or based on 
@@ -170,7 +171,7 @@ exports.describe = function (text) {
       delete this.befores[name];
       return this;
     },
-    
+
     //
     // ### Add HTTP Request-based Tests
     // The `.get()`, `.post()`, `.put()`, `.del()`, `.patch()` and `.head()` 
@@ -238,14 +239,14 @@ exports.describe = function (text) {
               'Content-Disposition': 'form-data; name="' + filePartName + '"; filename="' + filename + '"',
               'body': fileData
           });
-          
+
           request(outgoing, callback);
         });
       });
-      
+
       return this._request.apply(this, ['post'].concat(args));
     },
-    
+
     //
     // ### Add Test Assertions
     // Add test assertions with `.expect()`. There are a couple of options here:
@@ -257,7 +258,7 @@ exports.describe = function (text) {
     expect: function (/* [text, code, result, assert] */) {
       var args = Array.prototype.slice.call(arguments),
           text, code, result, test, context;
-      
+
       args.forEach(function (arg) {
         switch (typeof(arg)) {
           case 'number': code = arg; break;
@@ -266,15 +267,15 @@ exports.describe = function (text) {
           case 'function': test = arg; break;
         }
       });
-      
+
       context = this._currentTest(this.current);
-      
+
       // When using a custom test assertion function, both the assertion function
       // and a description are required or else we have no key in the JSON structure to use.
       if (text && !test || test && !text) {
         throw new Error('Both description and a custom test are required.');
       }
-      
+
       // Setup the custom test assertion if we have the appropriate arguments.
       if (text && test) {
         context[text] = function (err, res, body) {
@@ -282,7 +283,7 @@ exports.describe = function (text) {
           test.apply(context, arguments);
         };
       }
-      
+
       // Setup the response code test assertion if we have the appropriate arguments.
       if (code) {
         context['should respond with ' + code] = function (err, res, body) {
@@ -290,7 +291,7 @@ exports.describe = function (text) {
           assert.equal(res.statusCode, code);
         };
       }
-      
+
       // Setup the JSON response assertion if we have the appropriate arguments.
       if (result) {
         context['should respond with ' + JSON.stringify(result).substring(0, 50)] = function (err, res, body) {
@@ -303,10 +304,10 @@ exports.describe = function (text) {
           assert.deepEqual(testResult, result);
         };
       }
-      
+
       return this;
     },
-    
+
     //
     // Create some helper methods for setting important options
     // that will be later passed to `request`.
@@ -319,7 +320,7 @@ exports.describe = function (text) {
       this.outgoing.maxRedirects = max;
       return this;
     },
-    
+
     //
     // ### Perform Sequential Tests Easily
     // Since this object literal is designed to manage a single vows suite, 
@@ -338,7 +339,7 @@ exports.describe = function (text) {
       this.current = '';
       return this;
     },
-    
+
     //
     // ### Run Your Tests
     // Again, since we are managing a single vows suite in this object we 
@@ -356,7 +357,7 @@ exports.describe = function (text) {
       if (this.batch) {
         this.next();
       }
-      
+
       this.suite.export(target);
       return this;
     },
@@ -367,16 +368,16 @@ exports.describe = function (text) {
       if (this.batch) {
         this.next();
       }
-      
+
       if (!callback) {
         callback = options;
         options = {};
       }
-      
+
       this.suite.run(options, callback);
       return this;
     },
-    
+
     // ### Use Vows from APIeasy
     //extrapolating this allows us to add our own custom methods.
     inheritedMethods: ['get', 'post', 'del', 'put', 'patch', 'head', 'uploadFile'],
@@ -384,25 +385,25 @@ exports.describe = function (text) {
       if (this.batch) {
         this.next();
       }
-      
+
       //
       // injects `easy` methods into vows' suite to be able 
       // to switch back to APIEasy context
       //
       var self = this;
-      
+
       this.inheritedMethods.forEach(function (methodName) {
-        if (typeof self.suite[methodName] === 'undefined') {    
+        if (typeof self.suite[methodName] === 'undefined') {
           self.suite[methodName] = function () {
             return self[methodName].apply(self, arguments);
-          }
-        }  
+          };
+        }
       });
-      
+
       this.suite.addBatch.apply(this.suite, arguments);
       return this;
     },
-    
+
     //
     // ### Helpers and Utilities
     // `_request()` exists for the sake of DRY and simplicity and is designed to handle
@@ -417,20 +418,20 @@ exports.describe = function (text) {
           uri     = typeof args[0] === 'string' && args.shift(),
           data    = typeof args[0] === 'object' && args.shift(),
           params  = typeof args[0] === 'object' && args.shift(),
-          
+
           // custom request implementation function (outgoing, callaback),
           // should invoke callback(err, response, body) once done
           requestImpl = typeof args[0] === 'function' && args.shift(),
           port    = this.port && this.port !== 80 ? ':' + this.port : '',
           outgoing = clone(this.outgoing),
           fullUri, context;
-      
+
       //
       // Update the fullUri for this request with the passed uri
       // and the query string parameters (if any).
       //
       fullUri = distillPath(uri ? this.paths.concat([uri]) : this.paths);
-      
+
       //
       // Append the query string parameters to the `fullUri`. It's worth mentioning
       // here that if only a single object is provided to `_request()` it will assume
@@ -439,7 +440,7 @@ exports.describe = function (text) {
       if (params) {
         fullUri += '?' + qs.stringify(params);
       }
-      
+
       //
       // If the user has provided data, assume that it is JSON 
       // and set it to the `body` property of the options. 
@@ -450,7 +451,7 @@ exports.describe = function (text) {
       if (data) {
         if (this.outgoing.headers['Content-Type'] == 'application/x-www-form-urlencoded') {
           outgoing.body = qs.stringify(data);
-        } 
+        }
         else if (this.outgoing.headers['Content-Type'] == 'application/json') {
           outgoing.body = JSON.stringify(data);
         }
@@ -458,7 +459,7 @@ exports.describe = function (text) {
           outgoing.body = data;
         }
       }
-      
+
       //
       // Set the `uri` and `method` properties of the request options `outgoing`
       // using the information provided to this instance and `_request()`.
@@ -467,14 +468,15 @@ exports.describe = function (text) {
       outgoing.uri += this.auth ? this.auth + '@' : '';
       outgoing.uri += this.host + port + fullUri;
       outgoing.method = method;
-      
+      outgoing.strictSSL = this.strictSSL;
+
       //
       // Create the description for this test. This is currently static.
       // **Remark _(indexzero)_**: Do users care if these strings are configurable?
       //
       this.current = ['A', method.toUpperCase(), 'to', fullUri].join(' ');
       context = this._currentTest();
-      
+
       //
       // Add the topic for the specified request to the context of the current
       // batch used by this suite. 
@@ -490,14 +492,14 @@ exports.describe = function (text) {
           Object.keys(self.befores).forEach(function (name) {
             outgoing = self.befores[name](outgoing);
           }); 
-          
+
           if (requestImpl)
             requestImpl(outgoing, this.callback);
           else
             request(outgoing, this.callback);
         }
       };
-      
+
       //
       // Set the outgoing request options and set of before functions on the topic. 
       // This is used for test assertions, general consistency, and basically 
@@ -505,10 +507,10 @@ exports.describe = function (text) {
       //
       context[this.current].topic.outgoing = outgoing;
       context[this.current].topic.before   = this.befores;
-      
+
       return this;
     },
-    
+
     //
     // The vows data structure is read as a sentence constructred by 
     // keys in a nested JSON structure. This helper method is designed to 
@@ -517,17 +519,17 @@ exports.describe = function (text) {
     //
     _currentTest: function (text) {
       var last = this.batch;
-      
+
       // Nest into the batch JSON structure using the current `discussion` text. 
       this.discussion.forEach(function (text) {
         if (typeof last[text] !== 'object') {
           last[text] = {};
         }
-        
+
         // Capture the nested object
         last = last[text];
       });
-      
+
       return text ? last[text] : last;
     }
   };

--- a/lib/api-easy.js
+++ b/lib/api-easy.js
@@ -430,7 +430,7 @@ exports.describe = function (text) {
       // Update the fullUri for this request with the passed uri
       // and the query string parameters (if any).
       //
-      fullUri = distillPath(uri ? this.paths.concat([uri]) : this.paths);
+      fullUri = uri ? this.paths.concat([uri]) : this.paths;
 
       //
       // Append the query string parameters to the `fullUri`. It's worth mentioning
@@ -469,7 +469,7 @@ exports.describe = function (text) {
       outgoing.uri += this.host + port + fullUri;
       outgoing.method = method;
       outgoing.strictSSL = this.strictSSL;
-
+      
       //
       // Create the description for this test. This is currently static.
       // **Remark _(indexzero)_**: Do users care if these strings are configurable?


### PR DESCRIPTION
All our APIs require SSL, many of our dev instances use self-signed SSL certs so we need the option to turn off Node.js strict SSL checking. Without this option we often see "UNABLE_TO_VERIFY_LEAF_SIGNATURE" errors from request().
